### PR TITLE
Update metadata:name to be in line with other MCollective plugins.

### DIFF
--- a/agent/yum.ddl
+++ b/agent/yum.ddl
@@ -1,4 +1,4 @@
-metadata :name       => "Yum Agent",
+metadata :name       => "Yum",
   :description       => "This is an agent for invoking yum actions on nodes",
   :author            => "Nathan Powell <nathan@nathanpowell.org>",
   :liberal_borrowing => "From here:  https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/package/agent",

--- a/agent/yum.rb
+++ b/agent/yum.rb
@@ -7,7 +7,7 @@
 module MCollective
   module Agent
     class Yum<RPC::Agent
-      metadata :name      => "Yum Agent",
+      metadata :name      => "Yum",
        :description       => "This is an agent for invoking yum actions on nodes",
        :author            => "Nathan Powell <nathan@nathanpowell.org>",
        :liberal_borrowing => "From here:  https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/package/agent",

--- a/ext/redhat/mcollective-yum-agent.spec
+++ b/ext/redhat/mcollective-yum-agent.spec
@@ -1,4 +1,4 @@
-Name: mcollective-yum-agent
+Name: mcollective-yum
 Version: 0.4
 Release: 1%{?dist}
 Summary: MCollective Agent for interacting with the `yum` command


### PR DESCRIPTION
Small change in the name field will set 'mco plugin package' to create normal package names by default. This is in line with the other supported mco plugins such as service, puppet and filemgr. 

New: mcollective-yum-agent-1.0-1.el6.noarch.rpm
Old: mcollective-yum-agent-agent-1.0-1.el6.noarch.rpm